### PR TITLE
Fix grayscale texbins with alpha

### DIFF
--- a/gitadora-textool/Program.cs
+++ b/gitadora-textool/Program.cs
@@ -337,7 +337,7 @@ namespace gitadora_textool
                     {
                         for (int i = 0; i < 256; i++)
                         {
-                            Color c = Color.FromArgb((byte)i, (byte)i, (byte)i);
+                            Color c = Color.FromArgb((byte)i, (byte)i, (byte)i), (byte)i);
                             entries[i] = c;
                         }
                     } else


### PR DESCRIPTION
Grayscale textures in jubeat that had a transparent background were being extracted with black backgrounds.